### PR TITLE
Simplify devcron installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 FROM python:2.7
 MAINTAINER Hamilton Turner <hamiltont@gmail.com>
 
-# Need hg to download devcron
-RUN apt-get update && apt-get install -y mercurial
-
 # Yay devcron
-RUN pip install -e hg+https://bitbucket.org/dbenamy/devcron#egg=devcron
+RUN pip install devcron
 
 # Setup defaults
 RUN mkdir /cron && \


### PR DESCRIPTION
devcron can be installed with pip https://bitbucket.org/dbenamy/devcron/issues/1/pypi#comment-24723033
