### PR TITLE
python:2.7-slim, no need in mecurial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM python:2.7
+FROM python:2.7-slim
 MAINTAINER Hamilton Turner <hamiltont@gmail.com>
 
-# Need hg to download devcron
-RUN apt-get update && apt-get install -y mercurial
-
 # Yay devcron
-RUN pip install -e hg+https://bitbucket.org/dbenamy/devcron#egg=devcron
+RUN pip install https://bitbucket.org/dbenamy/devcron/get/tip.tar.gz
 
 # Setup defaults
 RUN mkdir /cron && \


### PR DESCRIPTION
1) Slim python has much less to download
2) Then in inherited backup Dockerfile I temporary install my own tools and then `apt-get autoremove -y`, it has much less to remove ;)
3) We don't need mercurial - bitbucket gives us just an archive for any branch or tag.

Here are build times and sizes:
original: 691.2 MB, 37.633s
patched: 195.6 MB, 4.672s

Please re-upload docker hub image ASAP !
